### PR TITLE
fix exit bug on gcc9

### DIFF
--- a/ikd_Tree.cpp
+++ b/ikd_Tree.cpp
@@ -178,6 +178,7 @@ void KD_TREE::stop_thread(){
 void * KD_TREE::multi_thread_ptr(void * arg){
     KD_TREE * handle = (KD_TREE*) arg;
     handle->multi_thread_rebuild();
+    return nullptr;
 }    
 
 void KD_TREE::multi_thread_rebuild(){


### PR DESCRIPTION
Hello.

I get a "segment fault" bug after exiting threads when I use gcc9 to compile codes.But gcc7 works fine.

I fix this bug by little change in "multi_thread_ptr" function.


