### PR TITLE
[Fix] "error: #error PCL requires C++14 or above"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(ikd_tree_demo)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread -O3")
 
 find_package(PCL 1.8 REQUIRED)
 


### PR DESCRIPTION
When calling "make -j 9" this PCL error would jump related to the C++ version.