### PR TITLE
Better C++ compatibility for branch fast_lio

### DIFF
--- a/ikd_Tree.cpp
+++ b/ikd_Tree.cpp
@@ -92,7 +92,7 @@ int KD_TREE<PointType>::size()
     }
     else
     {
-        if (!working_flag_mutex.try_lock())
+        if (true == working_flag_mutex.try_lock())
         {
             s = Root_Node->TreeSize;
             working_flag_mutex.unlock();
@@ -127,7 +127,7 @@ BoxPointType KD_TREE<PointType>::tree_range()
     }
     else
     {
-        if (!working_flag_mutex.try_lock())
+        if (true == working_flag_mutex.try_lock())
         {
             range.vertex_min[0] = Root_Node->node_range_x[0];
             range.vertex_min[1] = Root_Node->node_range_y[0];
@@ -158,7 +158,7 @@ int KD_TREE<PointType>::validnum()
     }
     else
     {
-        if (!working_flag_mutex.try_lock())
+        if (true == working_flag_mutex.try_lock())
         {
             s = Root_Node->TreeSize - Root_Node->invalid_point_num;
             working_flag_mutex.unlock();
@@ -182,7 +182,7 @@ void KD_TREE<PointType>::root_alpha(float &alpha_bal, float &alpha_del)
     }
     else
     {
-        if (!working_flag_mutex.try_lock())
+        if (true == working_flag_mutex.try_lock())
         {
             alpha_bal = Root_Node->alpha_bal;
             alpha_del = Root_Node->alpha_del;
@@ -735,7 +735,7 @@ void KD_TREE<PointType>::Rebuild(KD_TREE_NODE **root)
     KD_TREE_NODE *father_ptr;
     if ((*root)->TreeSize >= Multi_Thread_Rebuild_Point_Num)
     {
-        if (!rebuild_ptr_mutex_lock.try_lock())
+        if (true == rebuild_ptr_mutex_lock.try_lock())
         {
             if (Rebuild_Ptr == nullptr || ((*root)->TreeSize > (*Rebuild_Ptr)->TreeSize))
             {
@@ -1064,11 +1064,9 @@ void KD_TREE<PointType>::Search(KD_TREE_NODE *root, int k_nearest, PointType poi
     float max_dist_sqr = max_dist * max_dist;
     if (cur_dist > max_dist_sqr)
         return;
-    int retval;
     if (root->need_push_down_to_left || root->need_push_down_to_right)
     {
-        retval = root->push_down_mutex_lock.try_lock();
-        if (retval == 0)
+        if (true == root->push_down_mutex_lock.try_lock())
         {
             Push_Down(root);
             root->push_down_mutex_lock.unlock();

--- a/ikd_Tree.h
+++ b/ikd_Tree.h
@@ -17,8 +17,6 @@
 #define ForceRebuildPercentage 0.2
 #define Q_LEN 1000000
 
-using namespace std;
-
 // typedef pcl::PointXYZINormal PointType;
 // typedef vector<PointType, Eigen::aligned_allocator<PointType>>  PointVector;
 
@@ -325,13 +323,13 @@ public:
     int validnum();
     void root_alpha(float &alpha_bal, float &alpha_del);
     void Build(PointVector point_cloud);
-    void Nearest_Search(PointType point, int k_nearest, PointVector &Nearest_Points, vector<float> &Point_Distance, float max_dist = INFINITY);
+    void Nearest_Search(PointType point, int k_nearest, PointVector &Nearest_Points, std::vector<float> &Point_Distance, float max_dist = INFINITY);
     void Box_Search(const BoxPointType &Box_of_Point, PointVector &Storage);
     void Radius_Search(PointType point, const float radius, PointVector &Storage);
     int Add_Points(PointVector &PointToAdd, bool downsample_on);
-    void Add_Point_Boxes(vector<BoxPointType> &BoxPoints);
+    void Add_Point_Boxes(std::vector<BoxPointType> &BoxPoints);
     void Delete_Points(PointVector &PointToDel);
-    int Delete_Point_Boxes(vector<BoxPointType> &BoxPoints);
+    int Delete_Point_Boxes(std::vector<BoxPointType> &BoxPoints);
     void flatten(KD_TREE_NODE *root, PointVector &Storage, delete_point_storage_set storage_type);
     void acquire_removed_points(PointVector &removed_points);
     BoxPointType tree_range();

--- a/ikd_Tree.h
+++ b/ikd_Tree.h
@@ -4,11 +4,12 @@
 #include <pthread.h>
 #include <chrono>
 #include <time.h>
-#include <unistd.h>
+//#include <unistd.h>
 #include <math.h>
 #include <algorithm>
 #include <memory.h>
-#include <pcl/point_types.h>
+// #include <pcl/point_types.h>
+#include <Eigen/Core>
 
 #define EPSS 1e-6
 #define Minimal_Unbalanced_Tree_Size 10

--- a/ikd_Tree.h
+++ b/ikd_Tree.h
@@ -1,7 +1,8 @@
 #pragma once
 #include <stdio.h>
 #include <queue>
-#include <pthread.h>
+#include <thread>
+#include <mutex>
 #include <chrono>
 #include <time.h>
 //#include <unistd.h>
@@ -69,7 +70,7 @@ public:
         bool need_push_down_to_left = false;
         bool need_push_down_to_right = false;
         bool working_flag = false;
-        pthread_mutex_t push_down_mutex_lock;
+        std::mutex push_down_mutex_lock;
         float node_range_x[2], node_range_y[2], node_range_z[2];
         float radius_sq;
         KD_TREE_NODE *left_son_ptr = nullptr;
@@ -257,9 +258,9 @@ private:
     // Multi-thread Tree Rebuild
     bool termination_flag = false;
     bool rebuild_flag = false;
-    pthread_t rebuild_thread;
-    pthread_mutex_t termination_flag_mutex_lock, rebuild_ptr_mutex_lock, working_flag_mutex, search_flag_mutex;
-    pthread_mutex_t rebuild_logger_mutex_lock, points_deleted_rebuild_mutex_lock;
+    std::thread rebuild_thread;
+    std::mutex termination_flag_mutex_lock, rebuild_ptr_mutex_lock, working_flag_mutex, search_flag_mutex;
+    std::mutex rebuild_logger_mutex_lock, points_deleted_rebuild_mutex_lock;
     // queue<Operation_Logger_Type> Rebuild_Logger;
     MANUAL_Q Rebuild_Logger;
     PointVector Rebuild_PCL_Storage;


### PR DESCRIPTION
https://github.com/hku-mars/ikd-Tree/issues/22

Right now the header file is "using namespace std". This is considered bad practice, but easy to fix.

Additionally <unistd.h> is used to put the current thread to sleep.
This is not platform independent, but easily replaced by C++ std library functionality.

